### PR TITLE
Testing

### DIFF
--- a/atomics/T1055.012/T1055.012.md
+++ b/atomics/T1055.012/T1055.012.md
@@ -27,10 +27,10 @@ Credit to FuzzySecurity (https://github.com/FuzzySecurity/PowerShell-Suite/blob/
 #### Inputs:
 | Name | Description | Type | Default Value | 
 |------|-------------|------|---------------|
-| hollow_binary_path | Path of the binary to hollow (executable that will run inside the sponsor) | string | C:&#92;Windows&#92;System32&#92;cmd.exe|
+| hollow_binary_path | Path of the binary to hollow (executable that will run inside the sponsor) | string | C:&#92;Windows&#92;System32&#92;notepad.exe|
 | parent_process_name | Name of the parent process | string | explorer|
-| sponsor_binary_path | Path of the sponsor binary (executable that will host the binary) | string | C:&#92;Windows&#92;System32&#92;calc.exe|
-| spawnto_process_name | Name of the process to spawn | string | calc|
+| sponsor_binary_path | Path of the sponsor binary (executable that will host the binary) | string | C:&#92;Windows&#92;System32&#92;notepad.exe|
+| spawnto_process_name | Name of the process to spawn | string | notepad|
 
 
 #### Attack Commands: Run with `powershell`! 
@@ -55,7 +55,7 @@ Stop-Process -Name "#{spawnto_process_name}" -ErrorAction Ignore
 <br/>
 
 ## Atomic Test #2 - RunPE via VBA
-This module executes calc.exe from within the WINWORD.EXE process
+This module executes notepad.exe from within the WINWORD.EXE process
 
 **Supported Platforms:** Windows
 

--- a/atomics/T1055.012/T1055.012.md
+++ b/atomics/T1055.012/T1055.012.md
@@ -27,7 +27,7 @@ Credit to FuzzySecurity (https://github.com/FuzzySecurity/PowerShell-Suite/blob/
 #### Inputs:
 | Name | Description | Type | Default Value | 
 |------|-------------|------|---------------|
-| hollow_binary_path | Path of the binary to hollow (executable that will run inside the sponsor) | string | C:&#92;Windows&#92;System32&#92;notepad.exe|
+| hollow_binary_path | Path of the binary to hollow (executable that will run inside the sponsor) | string | C:&#92;Windows&#92;System32&#92;cmd.exe|
 | parent_process_name | Name of the parent process | string | explorer|
 | sponsor_binary_path | Path of the sponsor binary (executable that will host the binary) | string | C:&#92;Windows&#92;System32&#92;notepad.exe|
 | spawnto_process_name | Name of the process to spawn | string | notepad|

--- a/atomics/T1055.012/T1055.012.yaml
+++ b/atomics/T1055.012/T1055.012.yaml
@@ -20,11 +20,11 @@ atomic_tests:
     sponsor_binary_path:
       description: Path of the sponsor binary (executable that will host the binary)
       type: string
-      default: C:\Windows\System32\calc.exe
+      default: C:\Windows\System32\notepad.exe
     spawnto_process_name:
       description: Name of the process to spawn
       type: string
-      default: calc
+      default: notepad
   executor:
     command: |
       . $PathToAtomicsFolder\T1055.012\src\Start-Hollow.ps1
@@ -36,7 +36,7 @@ atomic_tests:
 - name: RunPE via VBA
   auto_generated_guid: 3ad4a037-1598-4136-837c-4027e4fa319b
   description: |
-    This module executes calc.exe from within the WINWORD.EXE process
+    This module executes notepad.exe from within the WINWORD.EXE process
   supported_platforms:
   - windows
   input_arguments:


### PR DESCRIPTION
**Details:**
Found that often times when executing this test that this nifty message would pop up:

![image](https://user-images.githubusercontent.com/55957823/115839750-d14d6480-a3cf-11eb-9779-16120e159cd3.png)

For test 1 the sponsor_binary_path is now C:\Windows\System32\notepad.exe
For test 2 the sponsor_binary_path is now C:\Windows\System32\notepad.exe

**Testing:**
Tested on remote machine I am using for my graduate research

**Associated Issues:**
N/A